### PR TITLE
Add vinyl record collection feature

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,9 +1,16 @@
 import { redirect } from "next/navigation";
-import { headers, cookies } from "next/headers";
+import { cookies } from "next/headers";
 import { NextRequest } from "next/server";
+import Link from "next/link";
 import { getSession } from "@/lib/auth";
-import { getAlbums } from "@/lib/photography";
-import UploadForm from "@/components/admin/UploadForm";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Card from "@mui/material/Card";
+import CardActionArea from "@mui/material/CardActionArea";
+import CardContent from "@mui/material/CardContent";
+import Stack from "@mui/material/Stack";
+import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
+import AlbumIcon from "@mui/icons-material/Album";
 
 export default async function AdminPage() {
   const cookieStore = await cookies();
@@ -16,8 +23,65 @@ export default async function AdminPage() {
   const session = await getSession(mockRequest);
   if (!session) redirect("/api/auth/login");
 
-  const albums = await getAlbums();
-  const albumNames = albums.map((a) => a.slug);
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        bgcolor: "background.default",
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        p: { xs: 2, sm: 4 },
+        pt: { xs: 4, sm: 8 },
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: 600 }}>
+        <Typography
+          variant="h3"
+          color="text.primary"
+          sx={{ mb: 4, fontWeight: 700 }}
+        >
+          Admin
+        </Typography>
 
-  return <UploadForm albums={albumNames} />;
+        <Stack spacing={2}>
+          <Card>
+            <CardActionArea component={Link} href="/admin/photos">
+              <CardContent>
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <PhotoCameraIcon
+                    sx={{ fontSize: 40, color: "secondary.main" }}
+                  />
+                  <Box>
+                    <Typography variant="h6">Photography</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Upload photos to albums
+                    </Typography>
+                  </Box>
+                </Stack>
+              </CardContent>
+            </CardActionArea>
+          </Card>
+
+          <Card>
+            <CardActionArea component={Link} href="/admin/vinyl">
+              <CardContent>
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <AlbumIcon
+                    sx={{ fontSize: 40, color: "secondary.main" }}
+                  />
+                  <Box>
+                    <Typography variant="h6">Vinyl Collection</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Import and manage records
+                    </Typography>
+                  </Box>
+                </Stack>
+              </CardContent>
+            </CardActionArea>
+          </Card>
+        </Stack>
+      </Box>
+    </Box>
+  );
 }

--- a/app/admin/photos/page.tsx
+++ b/app/admin/photos/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth";
+import { getAlbums } from "@/lib/photography";
+import UploadForm from "@/components/admin/UploadForm";
+
+export default async function AdminPhotosPage() {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+
+  const mockRequest = new NextRequest("http://localhost/admin/photos", {
+    headers: { cookie: cookieHeader },
+  });
+
+  const session = await getSession(mockRequest);
+  if (!session) redirect("/api/auth/login");
+
+  const albums = await getAlbums();
+  const albumNames = albums.map((a) => a.slug);
+
+  return <UploadForm albums={albumNames} />;
+}

--- a/app/admin/vinyl/page.tsx
+++ b/app/admin/vinyl/page.tsx
@@ -1,0 +1,19 @@
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth";
+import VinylAdmin from "@/components/admin/VinylAdmin";
+
+export default async function AdminVinylPage() {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+
+  const mockRequest = new NextRequest("http://localhost/admin/vinyl", {
+    headers: { cookie: cookieHeader },
+  });
+
+  const session = await getSession(mockRequest);
+  if (!session) redirect("/api/auth/login");
+
+  return <VinylAdmin />;
+}

--- a/app/api/vinyl/[id]/route.ts
+++ b/app/api/vinyl/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireSession } from "@/lib/auth";
+import { getRecordWithTracks, deleteRecordAndTracks } from "@/lib/vinyl";
+
+export const dynamic = "force-dynamic";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+
+  try {
+    const record = await getRecordWithTracks(id);
+    if (!record) {
+      return NextResponse.json({ error: "Record not found" }, { status: 404 });
+    }
+    return NextResponse.json(record);
+  } catch (err) {
+    console.error("Vinyl detail error:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch record" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const sessionOrResponse = await requireSession(request);
+  if (sessionOrResponse instanceof NextResponse) return sessionOrResponse;
+
+  const { id } = await params;
+
+  try {
+    await deleteRecordAndTracks(id);
+    return NextResponse.json({ deleted: true });
+  } catch (err) {
+    console.error("Vinyl delete error:", err);
+    return NextResponse.json(
+      { error: "Failed to delete record" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/vinyl/identify/route.ts
+++ b/app/api/vinyl/identify/route.ts
@@ -1,8 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { GetCommand } from "@aws-sdk/lib-dynamodb";
-import { getAllFingerprints, getRecord } from "@/lib/vinyl";
+import {
+  getAllFingerprints,
+  getRecord,
+  getTrack,
+  findTrackByMbid,
+  updateTrackFingerprint,
+} from "@/lib/vinyl";
 import { decodeChromaprint, compareFingerprints } from "@/lib/fingerprint";
-import { buildDynamoClient } from "@/lib/aws";
+import { lookupByFingerprint } from "@/lib/acoustid";
 
 export async function POST(request: NextRequest) {
   const apiKey = request.headers.get("x-api-key");
@@ -25,39 +30,41 @@ export async function POST(request: NextRequest) {
     }
 
     const query = decodeChromaprint(fingerprint);
+
     const candidates = await getAllFingerprints();
-
-    if (candidates.length === 0) {
-      return NextResponse.json({ match: null });
+    if (candidates.length > 0) {
+      const localMatch = compareFingerprints(query, candidates);
+      if (localMatch) {
+        const [record, track] = await Promise.all([
+          getRecord(localMatch.recordId),
+          getTrack(localMatch.trackId),
+        ]);
+        return NextResponse.json({
+          match: buildMatchResponse(record, track, localMatch.similarity),
+          source: "local",
+        });
+      }
     }
 
-    const result = compareFingerprints(query, candidates);
+    const acoustIdMatches = await lookupByFingerprint(fingerprint, duration);
 
-    if (!result) {
-      return NextResponse.json({ match: null });
+    for (const aMatch of acoustIdMatches) {
+      const track = await findTrackByMbid(aMatch.recordingMbid);
+      if (!track) continue;
+
+      const record = await getRecord(track.recordId);
+
+      updateTrackFingerprint(track.id, query).catch((err) =>
+        console.error(`Failed to save fingerprint for ${track.title}:`, err)
+      );
+
+      return NextResponse.json({
+        match: buildMatchResponse(record, track, aMatch.score),
+        source: "acoustid",
+      });
     }
 
-    const [record, track] = await Promise.all([
-      getRecord(result.recordId),
-      getTrack(result.trackId),
-    ]);
-
-    return NextResponse.json({
-      match: {
-        similarity: result.similarity,
-        track: track
-          ? { id: track.id, title: track.title, trackNumber: track.trackNumber }
-          : null,
-        record: record
-          ? {
-              id: record.id,
-              title: record.title,
-              artist: record.artist,
-              coverUrl: record.coverUrl,
-            }
-          : null,
-      },
-    });
+    return NextResponse.json({ match: null });
   } catch (err) {
     console.error("Identify error:", err);
     return NextResponse.json(
@@ -67,13 +74,23 @@ export async function POST(request: NextRequest) {
   }
 }
 
-async function getTrack(trackId: string) {
-  const db = buildDynamoClient();
-  const result = await db.send(
-    new GetCommand({
-      TableName: process.env.DYNAMODB_VINYL_TRACKS_TABLE!,
-      Key: { id: trackId },
-    })
-  );
-  return result.Item ?? null;
+function buildMatchResponse(
+  record: { id: string; title: string; artist: string; coverUrl: string | null } | null,
+  track: { id: string; title: string; trackNumber: number } | null,
+  similarity: number
+) {
+  return {
+    similarity,
+    track: track
+      ? { id: track.id, title: track.title, trackNumber: track.trackNumber }
+      : null,
+    record: record
+      ? {
+          id: record.id,
+          title: record.title,
+          artist: record.artist,
+          coverUrl: record.coverUrl,
+        }
+      : null,
+  };
 }

--- a/app/api/vinyl/identify/route.ts
+++ b/app/api/vinyl/identify/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import { getAllFingerprints, getRecord } from "@/lib/vinyl";
+import { decodeChromaprint, compareFingerprints } from "@/lib/fingerprint";
+import { buildDynamoClient } from "@/lib/aws";
+
+export async function POST(request: NextRequest) {
+  const apiKey = request.headers.get("x-api-key");
+  if (!apiKey || apiKey !== process.env.VINYL_IDENTIFY_API_KEY) {
+    return NextResponse.json(null, { status: 404 });
+  }
+
+  try {
+    const body = await request.json();
+    const { fingerprint, duration } = body as {
+      fingerprint: string;
+      duration: number;
+    };
+
+    if (!fingerprint) {
+      return NextResponse.json(
+        { error: "Missing fingerprint" },
+        { status: 400 }
+      );
+    }
+
+    const query = decodeChromaprint(fingerprint);
+    const candidates = await getAllFingerprints();
+
+    if (candidates.length === 0) {
+      return NextResponse.json({ match: null });
+    }
+
+    const result = compareFingerprints(query, candidates);
+
+    if (!result) {
+      return NextResponse.json({ match: null });
+    }
+
+    const [record, track] = await Promise.all([
+      getRecord(result.recordId),
+      getTrack(result.trackId),
+    ]);
+
+    return NextResponse.json({
+      match: {
+        similarity: result.similarity,
+        track: track
+          ? { id: track.id, title: track.title, trackNumber: track.trackNumber }
+          : null,
+        record: record
+          ? {
+              id: record.id,
+              title: record.title,
+              artist: record.artist,
+              coverUrl: record.coverUrl,
+            }
+          : null,
+      },
+    });
+  } catch (err) {
+    console.error("Identify error:", err);
+    return NextResponse.json(
+      { error: "Identification failed" },
+      { status: 500 }
+    );
+  }
+}
+
+async function getTrack(trackId: string) {
+  const db = buildDynamoClient();
+  const result = await db.send(
+    new GetCommand({
+      TableName: process.env.DYNAMODB_VINYL_TRACKS_TABLE!,
+      Key: { id: trackId },
+    })
+  );
+  return result.Item ?? null;
+}

--- a/app/api/vinyl/import/route.ts
+++ b/app/api/vinyl/import/route.ts
@@ -3,7 +3,6 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { requireSession } from "@/lib/auth";
 import { buildS3Client, bucket, cdnUrl } from "@/lib/aws";
 import { getReleaseTracks, getCoverArtUrl } from "@/lib/musicbrainz";
-import { lookupFingerprintByMbid } from "@/lib/acoustid";
 import { createRecord, createTracks } from "@/lib/vinyl";
 import type { VinylRecord, VinylTrack } from "@/types";
 
@@ -84,21 +83,9 @@ export async function POST(request: NextRequest) {
       await createTracks(tracks);
     }
 
-    let fingerprintsFound = 0;
-    const trackMbids = tracks.filter((t) => t.mbid);
-    if (trackMbids.length > 0) {
-      backfillFingerprints(trackMbids).then((count) => {
-        console.log(
-          `Backfilled ${count} fingerprints for "${title}" by ${artist}`
-        );
-      });
-    }
-
     return NextResponse.json({
       record,
       tracksImported: tracks.length,
-      fingerprintsFound,
-      fingerprintsBackfilling: trackMbids.length,
     });
   } catch (err) {
     console.error("Import error:", err);
@@ -107,30 +94,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
-
-async function backfillFingerprints(tracks: VinylTrack[]): Promise<number> {
-  const { createTracks: updateTracks } = await import("@/lib/vinyl");
-  let count = 0;
-
-  for (const track of tracks) {
-    if (!track.mbid) continue;
-    try {
-      await new Promise((r) => setTimeout(r, 1100));
-      const fp = await lookupFingerprintByMbid(track.mbid);
-      if (fp) {
-        track.fingerprint = fp;
-        count++;
-      }
-    } catch (err) {
-      console.error(`Fingerprint lookup failed for ${track.title}:`, err);
-    }
-  }
-
-  if (count > 0) {
-    const updated = tracks.filter((t) => t.fingerprint);
-    await updateTracks(updated);
-  }
-
-  return count;
 }

--- a/app/api/vinyl/import/route.ts
+++ b/app/api/vinyl/import/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { requireSession } from "@/lib/auth";
+import { buildS3Client, bucket, cdnUrl } from "@/lib/aws";
+import { getReleaseTracks, getCoverArtUrl } from "@/lib/musicbrainz";
+import { lookupFingerprintByMbid } from "@/lib/acoustid";
+import { createRecord, createTracks } from "@/lib/vinyl";
+import type { VinylRecord, VinylTrack } from "@/types";
+
+export async function POST(request: NextRequest) {
+  const sessionOrResponse = await requireSession(request);
+  if (sessionOrResponse instanceof NextResponse) return sessionOrResponse;
+
+  const body = await request.json();
+  const { releaseId, title, artist, year } = body as {
+    releaseId: string;
+    title: string;
+    artist: string;
+    year: number | null;
+  };
+
+  if (!releaseId || !title || !artist) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+
+  try {
+    const recordId = crypto.randomUUID();
+
+    const [mbTracks, coverArtUrl] = await Promise.all([
+      getReleaseTracks(releaseId),
+      getCoverArtUrl(releaseId),
+    ]);
+
+    let coverKey: string | null = null;
+    let coverUrl: string | null = null;
+
+    if (coverArtUrl) {
+      try {
+        const imgRes = await fetch(coverArtUrl);
+        if (imgRes.ok) {
+          const imgBuffer = Buffer.from(await imgRes.arrayBuffer());
+          coverKey = `vinyl/covers/${recordId}.jpg`;
+          const s3 = buildS3Client();
+          await s3.send(
+            new PutObjectCommand({
+              Bucket: bucket,
+              Key: coverKey,
+              Body: imgBuffer,
+              ContentType: "image/jpeg",
+            })
+          );
+          coverUrl = cdnUrl(coverKey);
+        }
+      } catch (err) {
+        console.error("Cover art upload failed:", err);
+      }
+    }
+
+    const tracks: VinylTrack[] = mbTracks.map((t) => ({
+      id: crypto.randomUUID(),
+      recordId,
+      title: t.title,
+      trackNumber: t.trackNumber,
+      discNumber: t.discNumber,
+      duration: t.duration,
+      mbid: t.recordingMbid,
+      fingerprint: null,
+    }));
+
+    const record: VinylRecord = {
+      id: recordId,
+      title,
+      artist,
+      year,
+      mbid: releaseId,
+      coverKey,
+      coverUrl,
+      trackCount: tracks.length,
+      createdAt: new Date().toISOString(),
+    };
+
+    await createRecord(record);
+    if (tracks.length > 0) {
+      await createTracks(tracks);
+    }
+
+    let fingerprintsFound = 0;
+    const trackMbids = tracks.filter((t) => t.mbid);
+    if (trackMbids.length > 0) {
+      backfillFingerprints(trackMbids).then((count) => {
+        console.log(
+          `Backfilled ${count} fingerprints for "${title}" by ${artist}`
+        );
+      });
+    }
+
+    return NextResponse.json({
+      record,
+      tracksImported: tracks.length,
+      fingerprintsFound,
+      fingerprintsBackfilling: trackMbids.length,
+    });
+  } catch (err) {
+    console.error("Import error:", err);
+    return NextResponse.json(
+      { error: "Failed to import record" },
+      { status: 500 }
+    );
+  }
+}
+
+async function backfillFingerprints(tracks: VinylTrack[]): Promise<number> {
+  const { createTracks: updateTracks } = await import("@/lib/vinyl");
+  let count = 0;
+
+  for (const track of tracks) {
+    if (!track.mbid) continue;
+    try {
+      await new Promise((r) => setTimeout(r, 1100));
+      const fp = await lookupFingerprintByMbid(track.mbid);
+      if (fp) {
+        track.fingerprint = fp;
+        count++;
+      }
+    } catch (err) {
+      console.error(`Fingerprint lookup failed for ${track.title}:`, err);
+    }
+  }
+
+  if (count > 0) {
+    const updated = tracks.filter((t) => t.fingerprint);
+    await updateTracks(updated);
+  }
+
+  return count;
+}

--- a/app/api/vinyl/preview/route.ts
+++ b/app/api/vinyl/preview/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireSession } from "@/lib/auth";
+import { getReleaseTracks, getCoverArtUrl } from "@/lib/musicbrainz";
+
+export async function GET(request: NextRequest) {
+  const sessionOrResponse = await requireSession(request);
+  if (sessionOrResponse instanceof NextResponse) return sessionOrResponse;
+
+  const releaseId = request.nextUrl.searchParams.get("id");
+  if (!releaseId) {
+    return NextResponse.json({ error: "Missing id" }, { status: 400 });
+  }
+
+  try {
+    const [tracks, coverArtUrl] = await Promise.all([
+      getReleaseTracks(releaseId),
+      getCoverArtUrl(releaseId),
+    ]);
+
+    return NextResponse.json({ tracks, coverArtUrl });
+  } catch (err) {
+    console.error("Preview error:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch release details" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/vinyl/route.ts
+++ b/app/api/vinyl/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { getAllRecords, getCollectionStats } from "@/lib/vinyl";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const [records, stats] = await Promise.all([
+      getAllRecords(),
+      getCollectionStats(),
+    ]);
+    return NextResponse.json({ records, stats });
+  } catch (err) {
+    console.error("Vinyl API error:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch vinyl collection" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/vinyl/search/route.ts
+++ b/app/api/vinyl/search/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireSession } from "@/lib/auth";
+import { searchReleases } from "@/lib/musicbrainz";
+
+export async function GET(request: NextRequest) {
+  const sessionOrResponse = await requireSession(request);
+  if (sessionOrResponse instanceof NextResponse) return sessionOrResponse;
+
+  const query = request.nextUrl.searchParams.get("q");
+  if (!query) {
+    return NextResponse.json({ error: "Missing query" }, { status: 400 });
+  }
+
+  try {
+    const releases = await searchReleases(query);
+    return NextResponse.json({ releases });
+  } catch (err) {
+    console.error("MusicBrainz search error:", err);
+    return NextResponse.json(
+      { error: "Failed to search MusicBrainz" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/vinyl/[id]/page.tsx
+++ b/app/vinyl/[id]/page.tsx
@@ -1,0 +1,16 @@
+import { notFound } from "next/navigation";
+import { getRecordWithTracks } from "@/lib/vinyl";
+import VinylDetail from "@/components/vinyl/VinylDetail";
+
+interface VinylDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function VinylDetailPage({ params }: VinylDetailPageProps) {
+  const { id } = await params;
+  const record = await getRecordWithTracks(id);
+
+  if (!record) notFound();
+
+  return <VinylDetail record={record} />;
+}

--- a/app/vinyl/layout.tsx
+++ b/app/vinyl/layout.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import type { Metadata } from "next";
+import Box from "@mui/material/Box";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Vinyl Collection | Ethan Wells",
+  description: "Vinyl record collection by Ethan Wells",
+};
+
+export default function VinylLayout({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        bgcolor: "background.default",
+        display: "flex",
+        justifyContent: "center",
+        p: { xs: 2, sm: 3 },
+        pt: { xs: 4, sm: 6 },
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: 1200 }}>{children}</Box>
+    </Box>
+  );
+}

--- a/app/vinyl/page.tsx
+++ b/app/vinyl/page.tsx
@@ -1,0 +1,68 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Stack from "@mui/material/Stack";
+import Chip from "@mui/material/Chip";
+import AlbumIcon from "@mui/icons-material/Album";
+import MusicNoteIcon from "@mui/icons-material/MusicNote";
+import PersonIcon from "@mui/icons-material/Person";
+import { getAllRecords, getCollectionStats } from "@/lib/vinyl";
+import VinylCard from "@/components/vinyl/VinylCard";
+
+export default async function VinylPage() {
+  const [records, stats] = await Promise.all([
+    getAllRecords(),
+    getCollectionStats(),
+  ]);
+
+  return (
+    <>
+      <Typography
+        variant="h3"
+        color="text.primary"
+        sx={{ mb: 1, fontWeight: 700 }}
+      >
+        Vinyl Collection
+      </Typography>
+
+      {stats.totalRecords > 0 && (
+        <Stack direction="row" spacing={1} sx={{ mb: 4 }}>
+          <Chip
+            icon={<AlbumIcon />}
+            label={`${stats.totalRecords} records`}
+            variant="outlined"
+          />
+          <Chip
+            icon={<PersonIcon />}
+            label={`${stats.uniqueArtists} artists`}
+            variant="outlined"
+          />
+          <Chip
+            icon={<MusicNoteIcon />}
+            label={`${stats.totalTracks} tracks`}
+            variant="outlined"
+          />
+        </Stack>
+      )}
+
+      {records.length === 0 ? (
+        <Typography color="text.secondary">No records yet.</Typography>
+      ) : (
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "repeat(2, 1fr)",
+              sm: "repeat(3, 1fr)",
+              md: "repeat(4, 1fr)",
+            },
+            gap: 3,
+          }}
+        >
+          {records.map((record) => (
+            <VinylCard key={record.id} record={record} />
+          ))}
+        </Box>
+      )}
+    </>
+  );
+}

--- a/components/admin/VinylAdmin.tsx
+++ b/components/admin/VinylAdmin.tsx
@@ -35,8 +35,6 @@ import type { MBRelease, MBTrack } from "@/lib/musicbrainz";
 interface ImportResult {
   record: VinylRecord;
   tracksImported: number;
-  fingerprintsFound: number;
-  fingerprintsBackfilling: number;
 }
 
 interface ReleasePreview {
@@ -375,8 +373,6 @@ export default function VinylAdmin() {
             <Alert severity="success" sx={{ mt: 2 }}>
               Imported &quot;{importResult.record.title}&quot; —{" "}
               {importResult.tracksImported} tracks.
-              {importResult.fingerprintsBackfilling > 0 &&
-                ` Backfilling ${importResult.fingerprintsBackfilling} fingerprints in background.`}
             </Alert>
           )}
         </Paper>

--- a/components/admin/VinylAdmin.tsx
+++ b/components/admin/VinylAdmin.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+/* eslint-disable @next/next/no-img-element */
 import { useState, useEffect } from "react";
 import {
   Box,
@@ -16,19 +17,38 @@ import {
   IconButton,
   Divider,
   Alert,
+  Collapse,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AlbumIcon from "@mui/icons-material/Album";
 import LogoutIcon from "@mui/icons-material/Logout";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import type { VinylRecord } from "@/types";
-import type { MBRelease } from "@/lib/musicbrainz";
+import type { MBRelease, MBTrack } from "@/lib/musicbrainz";
 
 interface ImportResult {
   record: VinylRecord;
   tracksImported: number;
   fingerprintsFound: number;
   fingerprintsBackfilling: number;
+}
+
+interface ReleasePreview {
+  tracks: MBTrack[];
+  coverArtUrl: string | null;
+}
+
+function formatDuration(seconds: number | null): string {
+  if (!seconds) return "—";
+  const min = Math.floor(seconds / 60);
+  const sec = seconds % 60;
+  return `${min}:${sec.toString().padStart(2, "0")}`;
 }
 
 export default function VinylAdmin() {
@@ -40,6 +60,9 @@ export default function VinylAdmin() {
   const [records, setRecords] = useState<VinylRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [previews, setPreviews] = useState<Record<string, ReleasePreview>>({});
+  const [loadingPreview, setLoadingPreview] = useState<string | null>(null);
 
   useEffect(() => {
     fetchCollection();
@@ -63,6 +86,8 @@ export default function VinylAdmin() {
     setSearching(true);
     setResults([]);
     setImportResult(null);
+    setExpandedId(null);
+    setPreviews({});
     setError(null);
 
     try {
@@ -76,6 +101,32 @@ export default function VinylAdmin() {
       setError("Search failed");
     } finally {
       setSearching(false);
+    }
+  }
+
+  async function handleExpand(releaseId: string) {
+    if (expandedId === releaseId) {
+      setExpandedId(null);
+      return;
+    }
+
+    setExpandedId(releaseId);
+
+    if (previews[releaseId]) return;
+
+    setLoadingPreview(releaseId);
+    try {
+      const res = await fetch(
+        `/api/vinyl/preview?id=${encodeURIComponent(releaseId)}`
+      );
+      if (!res.ok) throw new Error("Preview failed");
+      const data = await res.json();
+      setPreviews((prev) => ({ ...prev, [releaseId]: data }));
+    } catch {
+      setError("Failed to load release details");
+      setExpandedId(null);
+    } finally {
+      setLoadingPreview(null);
     }
   }
 
@@ -100,6 +151,8 @@ export default function VinylAdmin() {
       setImportResult(data);
       setResults([]);
       setQuery("");
+      setExpandedId(null);
+      setPreviews({});
       await fetchCollection();
     } catch {
       setError("Import failed");
@@ -142,7 +195,11 @@ export default function VinylAdmin() {
           alignItems="center"
           mb={3}
         >
-          <Typography variant="h3" color="text.primary" sx={{ fontSize: { xs: "1.75rem", sm: "3rem" } }}>
+          <Typography
+            variant="h3"
+            color="text.primary"
+            sx={{ fontSize: { xs: "1.75rem", sm: "3rem" } }}
+          >
             Vinyl Collection
           </Typography>
           <Button
@@ -190,29 +247,112 @@ export default function VinylAdmin() {
 
           {results.length > 0 && (
             <List sx={{ mt: 2 }}>
-              {results.map((release) => (
-                <ListItem
-                  key={release.id}
-                  divider
-                  sx={{ flexDirection: { xs: "column", sm: "row" }, alignItems: { xs: "flex-start", sm: "center" }, gap: 1 }}
-                >
-                  <ListItemText
-                    primary={release.title}
-                    secondary={`${release.artist}${release.year ? ` (${release.year})` : ""} — ${release.trackCount} tracks`}
-                  />
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    color="secondary"
-                    onClick={() => handleImport(release)}
-                    disabled={importing !== null}
-                    startIcon={<AlbumIcon />}
-                    sx={{ flexShrink: 0 }}
-                  >
-                    {importing === release.id ? "Importing..." : "Import"}
-                  </Button>
-                </ListItem>
-              ))}
+              {results.map((release) => {
+                const preview = previews[release.id];
+                const isExpanded = expandedId === release.id;
+
+                return (
+                  <Box key={release.id}>
+                    <ListItem
+                      divider={!isExpanded}
+                      sx={{
+                        flexDirection: { xs: "column", sm: "row" },
+                        alignItems: { xs: "flex-start", sm: "center" },
+                        gap: 1,
+                        cursor: "pointer",
+                      }}
+                      onClick={() => handleExpand(release.id)}
+                    >
+                      <ListItemText
+                        primary={release.title}
+                        secondary={`${release.artist}${release.year ? ` (${release.year})` : ""} — ${release.trackCount} tracks`}
+                      />
+                      <Stack direction="row" spacing={1} sx={{ flexShrink: 0 }}>
+                        <IconButton size="small">
+                          {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                        </IconButton>
+                      </Stack>
+                    </ListItem>
+
+                    <Collapse in={isExpanded}>
+                      <Box sx={{ px: 2, pb: 2 }}>
+                        {loadingPreview === release.id && (
+                          <LinearProgress color="secondary" sx={{ mb: 2 }} />
+                        )}
+
+                        {preview && (
+                          <Stack
+                            direction={{ xs: "column", sm: "row" }}
+                            spacing={2}
+                            sx={{ mb: 2 }}
+                          >
+                            {preview.coverArtUrl && (
+                              <Box sx={{ flexShrink: 0 }}>
+                                <img
+                                  src={preview.coverArtUrl}
+                                  alt={release.title}
+                                  style={{
+                                    width: 120,
+                                    height: 120,
+                                    objectFit: "cover",
+                                    borderRadius: 8,
+                                  }}
+                                />
+                              </Box>
+                            )}
+                            <Box sx={{ flexGrow: 1, overflow: "hidden" }}>
+                              <Table size="small">
+                                <TableBody>
+                                  {preview.tracks.map((track) => (
+                                    <TableRow key={`${track.discNumber}-${track.trackNumber}`}>
+                                      <TableCell sx={{ width: 30, px: 0.5 }}>
+                                        {track.trackNumber}
+                                      </TableCell>
+                                      <TableCell sx={{ px: 0.5 }}>
+                                        <Typography variant="body2" noWrap>
+                                          {track.title}
+                                        </Typography>
+                                      </TableCell>
+                                      <TableCell
+                                        align="right"
+                                        sx={{ width: 50, px: 0.5 }}
+                                      >
+                                        <Typography
+                                          variant="body2"
+                                          color="text.secondary"
+                                        >
+                                          {formatDuration(track.duration)}
+                                        </Typography>
+                                      </TableCell>
+                                    </TableRow>
+                                  ))}
+                                </TableBody>
+                              </Table>
+                            </Box>
+                          </Stack>
+                        )}
+
+                        <Button
+                          variant="contained"
+                          color="secondary"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleImport(release);
+                          }}
+                          disabled={importing !== null}
+                          startIcon={<AlbumIcon />}
+                          fullWidth
+                        >
+                          {importing === release.id
+                            ? "Importing..."
+                            : "Import this album"}
+                        </Button>
+                      </Box>
+                      <Divider />
+                    </Collapse>
+                  </Box>
+                );
+              })}
             </List>
           )}
 

--- a/components/admin/VinylAdmin.tsx
+++ b/components/admin/VinylAdmin.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  Typography,
+  TextField,
+  Paper,
+  Stack,
+  Chip,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+  Divider,
+  Alert,
+} from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AlbumIcon from "@mui/icons-material/Album";
+import LogoutIcon from "@mui/icons-material/Logout";
+import type { VinylRecord } from "@/types";
+import type { MBRelease } from "@/lib/musicbrainz";
+
+interface ImportResult {
+  record: VinylRecord;
+  tracksImported: number;
+  fingerprintsFound: number;
+  fingerprintsBackfilling: number;
+}
+
+export default function VinylAdmin() {
+  const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [results, setResults] = useState<MBRelease[]>([]);
+  const [importing, setImporting] = useState<string | null>(null);
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const [records, setRecords] = useState<VinylRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchCollection();
+  }, []);
+
+  async function fetchCollection() {
+    try {
+      const res = await fetch("/api/vinyl");
+      if (!res.ok) throw new Error("Failed to fetch collection");
+      const data = await res.json();
+      setRecords(data.records);
+    } catch {
+      setError("Failed to load collection");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSearch() {
+    if (!query.trim()) return;
+    setSearching(true);
+    setResults([]);
+    setImportResult(null);
+    setError(null);
+
+    try {
+      const res = await fetch(
+        `/api/vinyl/search?q=${encodeURIComponent(query)}`
+      );
+      if (!res.ok) throw new Error("Search failed");
+      const data = await res.json();
+      setResults(data.releases);
+    } catch {
+      setError("Search failed");
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  async function handleImport(release: MBRelease) {
+    setImporting(release.id);
+    setImportResult(null);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/vinyl/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          releaseId: release.id,
+          title: release.title,
+          artist: release.artist,
+          year: release.year,
+        }),
+      });
+      if (!res.ok) throw new Error("Import failed");
+      const data = await res.json();
+      setImportResult(data);
+      setResults([]);
+      setQuery("");
+      await fetchCollection();
+    } catch {
+      setError("Import failed");
+    } finally {
+      setImporting(null);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    try {
+      const res = await fetch(`/api/vinyl/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Delete failed");
+      setRecords((prev) => prev.filter((r) => r.id !== id));
+    } catch {
+      setError("Delete failed");
+    }
+  }
+
+  async function handleLogout() {
+    await fetch("/api/auth/logout", { method: "POST" });
+    window.location.href = "/";
+  }
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        bgcolor: "background.default",
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        p: { xs: 2, sm: 4 },
+        pt: { xs: 4, sm: 8 },
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: 700 }}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          mb={3}
+        >
+          <Typography variant="h3" color="text.primary" sx={{ fontSize: { xs: "1.75rem", sm: "3rem" } }}>
+            Vinyl Collection
+          </Typography>
+          <Button
+            startIcon={<LogoutIcon />}
+            onClick={handleLogout}
+            variant="outlined"
+            color="secondary"
+            size="small"
+          >
+            Logout
+          </Button>
+        </Stack>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        <Paper sx={{ p: 3, mb: 3 }}>
+          <Typography variant="h6" gutterBottom>
+            Import from MusicBrainz
+          </Typography>
+          <Stack direction="row" spacing={2}>
+            <TextField
+              fullWidth
+              size="small"
+              placeholder="Search for an album..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+            />
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={handleSearch}
+              disabled={searching || !query.trim()}
+              startIcon={<SearchIcon />}
+            >
+              Search
+            </Button>
+          </Stack>
+
+          {searching && <LinearProgress color="secondary" sx={{ mt: 2 }} />}
+
+          {results.length > 0 && (
+            <List sx={{ mt: 2 }}>
+              {results.map((release) => (
+                <ListItem
+                  key={release.id}
+                  divider
+                  sx={{ flexDirection: { xs: "column", sm: "row" }, alignItems: { xs: "flex-start", sm: "center" }, gap: 1 }}
+                >
+                  <ListItemText
+                    primary={release.title}
+                    secondary={`${release.artist}${release.year ? ` (${release.year})` : ""} — ${release.trackCount} tracks`}
+                  />
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    color="secondary"
+                    onClick={() => handleImport(release)}
+                    disabled={importing !== null}
+                    startIcon={<AlbumIcon />}
+                    sx={{ flexShrink: 0 }}
+                  >
+                    {importing === release.id ? "Importing..." : "Import"}
+                  </Button>
+                </ListItem>
+              ))}
+            </List>
+          )}
+
+          {importing && (
+            <LinearProgress color="secondary" sx={{ mt: 2 }} />
+          )}
+
+          {importResult && (
+            <Alert severity="success" sx={{ mt: 2 }}>
+              Imported &quot;{importResult.record.title}&quot; —{" "}
+              {importResult.tracksImported} tracks.
+              {importResult.fingerprintsBackfilling > 0 &&
+                ` Backfilling ${importResult.fingerprintsBackfilling} fingerprints in background.`}
+            </Alert>
+          )}
+        </Paper>
+
+        <Paper sx={{ p: 3 }}>
+          <Typography variant="h6" gutterBottom>
+            Collection ({records.length} records)
+          </Typography>
+
+          {loading && <LinearProgress color="secondary" />}
+
+          {!loading && records.length === 0 && (
+            <Typography color="text.secondary">
+              No records yet. Search and import above.
+            </Typography>
+          )}
+
+          {records.length > 0 && (
+            <List>
+              {records.map((record, i) => (
+                <Box key={record.id}>
+                  {i > 0 && <Divider />}
+                  <ListItem>
+                    <ListItemText
+                      primary={record.title}
+                      secondary={
+                        <Stack direction="row" spacing={1} component="span">
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            component="span"
+                          >
+                            {record.artist}
+                          </Typography>
+                          {record.year && (
+                            <Chip
+                              label={record.year}
+                              size="small"
+                              variant="outlined"
+                            />
+                          )}
+                          <Chip
+                            label={`${record.trackCount} tracks`}
+                            size="small"
+                            variant="outlined"
+                          />
+                        </Stack>
+                      }
+                    />
+                    <IconButton
+                      edge="end"
+                      onClick={() => handleDelete(record.id)}
+                      color="error"
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </ListItem>
+                </Box>
+              ))}
+            </List>
+          )}
+        </Paper>
+      </Box>
+    </Box>
+  );
+}

--- a/components/admin/VinylAdmin.tsx
+++ b/components/admin/VinylAdmin.tsx
@@ -402,29 +402,7 @@ export default function VinylAdmin() {
                   <ListItem>
                     <ListItemText
                       primary={record.title}
-                      secondary={
-                        <Stack direction="row" spacing={1} component="span">
-                          <Typography
-                            variant="body2"
-                            color="text.secondary"
-                            component="span"
-                          >
-                            {record.artist}
-                          </Typography>
-                          {record.year && (
-                            <Chip
-                              label={record.year}
-                              size="small"
-                              variant="outlined"
-                            />
-                          )}
-                          <Chip
-                            label={`${record.trackCount} tracks`}
-                            size="small"
-                            variant="outlined"
-                          />
-                        </Stack>
-                      }
+                      secondary={`${record.artist}${record.year ? ` (${record.year})` : ""} — ${record.trackCount} tracks`}
                     />
                     <IconButton
                       edge="end"

--- a/components/admin/VinylAdmin.tsx
+++ b/components/admin/VinylAdmin.tsx
@@ -60,9 +60,9 @@ export default function VinylAdmin() {
   const [records, setRecords] = useState<VinylRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [previews, setPreviews] = useState<Record<string, ReleasePreview>>({});
-  const [loadingPreview, setLoadingPreview] = useState<string | null>(null);
+  const [loadingPreviews, setLoadingPreviews] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     fetchCollection();
@@ -86,7 +86,7 @@ export default function VinylAdmin() {
     setSearching(true);
     setResults([]);
     setImportResult(null);
-    setExpandedId(null);
+    setExpandedIds(new Set());
     setPreviews({});
     setError(null);
 
@@ -105,16 +105,19 @@ export default function VinylAdmin() {
   }
 
   async function handleExpand(releaseId: string) {
-    if (expandedId === releaseId) {
-      setExpandedId(null);
-      return;
-    }
-
-    setExpandedId(releaseId);
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(releaseId)) {
+        next.delete(releaseId);
+      } else {
+        next.add(releaseId);
+      }
+      return next;
+    });
 
     if (previews[releaseId]) return;
 
-    setLoadingPreview(releaseId);
+    setLoadingPreviews((prev) => new Set(prev).add(releaseId));
     try {
       const res = await fetch(
         `/api/vinyl/preview?id=${encodeURIComponent(releaseId)}`
@@ -124,9 +127,17 @@ export default function VinylAdmin() {
       setPreviews((prev) => ({ ...prev, [releaseId]: data }));
     } catch {
       setError("Failed to load release details");
-      setExpandedId(null);
+      setExpandedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(releaseId);
+        return next;
+      });
     } finally {
-      setLoadingPreview(null);
+      setLoadingPreviews((prev) => {
+        const next = new Set(prev);
+        next.delete(releaseId);
+        return next;
+      });
     }
   }
 
@@ -151,7 +162,7 @@ export default function VinylAdmin() {
       setImportResult(data);
       setResults([]);
       setQuery("");
-      setExpandedId(null);
+      setExpandedIds(new Set());
       setPreviews({});
       await fetchCollection();
     } catch {
@@ -249,7 +260,7 @@ export default function VinylAdmin() {
             <List sx={{ mt: 2 }}>
               {results.map((release) => {
                 const preview = previews[release.id];
-                const isExpanded = expandedId === release.id;
+                const isExpanded = expandedIds.has(release.id);
 
                 return (
                   <Box key={release.id}>
@@ -276,7 +287,7 @@ export default function VinylAdmin() {
 
                     <Collapse in={isExpanded}>
                       <Box sx={{ px: 2, pb: 2 }}>
-                        {loadingPreview === release.id && (
+                        {loadingPreviews.has(release.id) && (
                           <LinearProgress color="secondary" sx={{ mb: 2 }} />
                         )}
 

--- a/components/homepage/NavBar.tsx
+++ b/components/homepage/NavBar.tsx
@@ -61,6 +61,9 @@ export function NavBar() {
           <Button component={Link} href="/photography" sx={navButtonSx}>
             Photography
           </Button>
+          <Button component={Link} href="/vinyl" sx={navButtonSx}>
+            Vinyl
+          </Button>
         </Box>
 
         <IconButton
@@ -102,6 +105,15 @@ export function NavBar() {
               >
                 <ListItemText
                   primary={<Typography sx={{ fontWeight: 600, fontSize: "1.1rem" }}>Photography</Typography>}
+                />
+              </ListItemButton>
+              <ListItemButton
+                component={Link}
+                href="/vinyl"
+                onClick={() => setDrawerOpen(false)}
+              >
+                <ListItemText
+                  primary={<Typography sx={{ fontWeight: 600, fontSize: "1.1rem" }}>Vinyl</Typography>}
                 />
               </ListItemButton>
             </List>

--- a/components/vinyl/VinylCard.tsx
+++ b/components/vinyl/VinylCard.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import Link from "next/link";
+import Card from "@mui/material/Card";
+import CardActionArea from "@mui/material/CardActionArea";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import AlbumIcon from "@mui/icons-material/Album";
+import type { VinylRecord } from "@/types";
+
+interface VinylCardProps {
+  record: VinylRecord;
+}
+
+export default function VinylCard({ record }: VinylCardProps) {
+  return (
+    <Card sx={{ bgcolor: "background.default" }}>
+      <CardActionArea component={Link} href={`/vinyl/${record.id}`}>
+        <Box
+          sx={{
+            position: "relative",
+            paddingTop: "100%",
+            bgcolor: "background.paper",
+            overflow: "hidden",
+          }}
+        >
+          {record.coverUrl ? (
+            <img
+              src={record.coverUrl}
+              alt={`${record.title} by ${record.artist}`}
+              loading="lazy"
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+              }}
+            />
+          ) : (
+            <Box
+              sx={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <AlbumIcon sx={{ fontSize: 64, color: "text.secondary" }} />
+            </Box>
+          )}
+          <Box
+            sx={{
+              position: "absolute",
+              bottom: 0,
+              left: 0,
+              right: 0,
+              background:
+                "linear-gradient(transparent, rgba(0,0,0,0.85))",
+              p: 1.5,
+              pt: 4,
+            }}
+          >
+            <Typography
+              variant="subtitle2"
+              sx={{ color: "#fff", lineHeight: 1.3 }}
+              noWrap
+            >
+              {record.title}
+            </Typography>
+            <Typography
+              variant="caption"
+              sx={{ color: "rgba(255,255,255,0.7)" }}
+              noWrap
+            >
+              {record.artist}
+            </Typography>
+          </Box>
+        </Box>
+      </CardActionArea>
+    </Card>
+  );
+}

--- a/components/vinyl/VinylDetail.tsx
+++ b/components/vinyl/VinylDetail.tsx
@@ -1,0 +1,147 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Chip from "@mui/material/Chip";
+import Stack from "@mui/material/Stack";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import Button from "@mui/material/Button";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import AlbumIcon from "@mui/icons-material/Album";
+import Link from "next/link";
+import type { VinylRecordWithTracks } from "@/types";
+
+interface VinylDetailProps {
+  record: VinylRecordWithTracks;
+}
+
+function formatDuration(seconds: number | null): string {
+  if (!seconds) return "—";
+  const min = Math.floor(seconds / 60);
+  const sec = seconds % 60;
+  return `${min}:${sec.toString().padStart(2, "0")}`;
+}
+
+export default function VinylDetail({ record }: VinylDetailProps) {
+  const hasMultipleDiscs = record.tracks.some((t) => t.discNumber > 1);
+
+  return (
+    <>
+      <Button
+        component={Link}
+        href="/vinyl"
+        startIcon={<ArrowBackIcon />}
+        sx={{ mb: 3, color: "text.secondary" }}
+      >
+        Back to Collection
+      </Button>
+
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: { xs: "column", md: "row" },
+          gap: 4,
+          mb: 4,
+        }}
+      >
+        <Box
+          sx={{
+            width: { xs: "100%", md: 300 },
+            flexShrink: 0,
+          }}
+        >
+          {record.coverUrl ? (
+            <img
+              src={record.coverUrl}
+              alt={`${record.title} by ${record.artist}`}
+              style={{
+                width: "100%",
+                borderRadius: 8,
+                display: "block",
+              }}
+            />
+          ) : (
+            <Box
+              sx={{
+                width: "100%",
+                paddingTop: "100%",
+                position: "relative",
+                bgcolor: "background.paper",
+                borderRadius: 2,
+              }}
+            >
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: "100%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <AlbumIcon sx={{ fontSize: 80, color: "text.secondary" }} />
+              </Box>
+            </Box>
+          )}
+        </Box>
+
+        <Box>
+          <Typography variant="h3" color="text.primary" sx={{ fontWeight: 700 }}>
+            {record.title}
+          </Typography>
+          <Typography variant="h5" color="text.secondary" sx={{ mb: 2 }}>
+            {record.artist}
+          </Typography>
+          <Stack direction="row" spacing={1}>
+            {record.year && <Chip label={record.year} variant="outlined" />}
+            <Chip
+              label={`${record.trackCount} tracks`}
+              variant="outlined"
+            />
+          </Stack>
+        </Box>
+      </Box>
+
+      {record.tracks.length > 0 && (
+        <TableContainer component={Paper} sx={{ bgcolor: "background.paper" }}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ width: 60 }}>#</TableCell>
+                <TableCell>Title</TableCell>
+                <TableCell align="right" sx={{ width: 80 }}>
+                  Duration
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {record.tracks.map((track) => (
+                <TableRow key={track.id} hover>
+                  <TableCell>
+                    {hasMultipleDiscs
+                      ? `${track.discNumber}.${track.trackNumber}`
+                      : track.trackNumber}
+                  </TableCell>
+                  <TableCell>{track.title}</TableCell>
+                  <TableCell align="right">
+                    {formatDuration(track.duration)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </>
+  );
+}

--- a/lib/acoustid.ts
+++ b/lib/acoustid.ts
@@ -1,46 +1,47 @@
 const ACOUSTID_URL = "https://api.acoustid.org/v2/lookup";
 
-export async function lookupFingerprintByMbid(
-  recordingMbid: string
-): Promise<number[] | null> {
+export interface AcoustIdMatch {
+  recordingMbid: string;
+  score: number;
+}
+
+export async function lookupByFingerprint(
+  fingerprint: string,
+  duration: number
+): Promise<AcoustIdMatch[]> {
   const apiKey = process.env.ACOUSTID_API_KEY;
-  if (!apiKey) return null;
+  if (!apiKey) return [];
 
   try {
-    const params = new URLSearchParams({
-      client: apiKey,
-      meta: "fingerprints",
-      recordingid: recordingMbid,
-      format: "json",
+    const res = await fetch(ACOUSTID_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client: apiKey,
+        meta: "recordings",
+        fingerprint,
+        duration: String(Math.round(duration)),
+        format: "json",
+      }),
     });
-
-    const res = await fetch(
-      `${ACOUSTID_URL}?${params.toString()}&lookup_type=recordingid`
-    );
-    if (!res.ok) return null;
+    if (!res.ok) return [];
 
     const data = await res.json();
-    const results = data.results ?? [];
+    const matches: AcoustIdMatch[] = [];
 
-    for (const result of results) {
-      for (const fingerprint of result.fingerprints ?? []) {
-        if (fingerprint.fingerprint) {
-          return decodeAcoustIdFingerprint(fingerprint.fingerprint);
+    for (const result of data.results ?? []) {
+      for (const recording of result.recordings ?? []) {
+        if (recording.id) {
+          matches.push({
+            recordingMbid: recording.id,
+            score: result.score ?? 0,
+          });
         }
       }
     }
 
-    return null;
+    return matches;
   } catch {
-    return null;
+    return [];
   }
-}
-
-function decodeAcoustIdFingerprint(encoded: string): number[] {
-  const raw = Buffer.from(encoded, "base64");
-  const values: number[] = [];
-  for (let i = 0; i + 3 < raw.length; i += 4) {
-    values.push(raw.readUInt32LE(i));
-  }
-  return values;
 }

--- a/lib/acoustid.ts
+++ b/lib/acoustid.ts
@@ -1,0 +1,46 @@
+const ACOUSTID_URL = "https://api.acoustid.org/v2/lookup";
+
+export async function lookupFingerprintByMbid(
+  recordingMbid: string
+): Promise<number[] | null> {
+  const apiKey = process.env.ACOUSTID_API_KEY;
+  if (!apiKey) return null;
+
+  try {
+    const params = new URLSearchParams({
+      client: apiKey,
+      meta: "fingerprints",
+      recordingid: recordingMbid,
+      format: "json",
+    });
+
+    const res = await fetch(
+      `${ACOUSTID_URL}?${params.toString()}&lookup_type=recordingid`
+    );
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    const results = data.results ?? [];
+
+    for (const result of results) {
+      for (const fingerprint of result.fingerprints ?? []) {
+        if (fingerprint.fingerprint) {
+          return decodeAcoustIdFingerprint(fingerprint.fingerprint);
+        }
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function decodeAcoustIdFingerprint(encoded: string): number[] {
+  const raw = Buffer.from(encoded, "base64");
+  const values: number[] = [];
+  for (let i = 0; i + 3 < raw.length; i += 4) {
+    values.push(raw.readUInt32LE(i));
+  }
+  return values;
+}

--- a/lib/aws.ts
+++ b/lib/aws.ts
@@ -1,0 +1,33 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { awsCredentialsProvider } from "@vercel/functions/oidc";
+
+function buildCredentials() {
+  if (process.env.VERCEL) {
+    return awsCredentialsProvider({ roleArn: process.env.AWS_ROLE_ARN! });
+  }
+  return undefined;
+}
+
+export function buildS3Client(): S3Client {
+  return new S3Client({
+    region: process.env.AWS_REGION,
+    credentials: buildCredentials(),
+  });
+}
+
+export function buildDynamoClient(): DynamoDBDocumentClient {
+  const client = new DynamoDBClient({
+    region: process.env.AWS_REGION,
+    credentials: buildCredentials(),
+  });
+  return DynamoDBDocumentClient.from(client);
+}
+
+export const bucket = process.env.S3_BUCKET_NAME!;
+export const cdnDomain = process.env.CLOUDFRONT_DOMAIN!;
+
+export function cdnUrl(key: string): string {
+  return `https://${cdnDomain}/${key}`;
+}

--- a/lib/fingerprint.ts
+++ b/lib/fingerprint.ts
@@ -1,0 +1,58 @@
+export function decodeChromaprint(base64: string): number[] {
+  const raw = Buffer.from(base64, "base64");
+  const values: number[] = [];
+  for (let i = 0; i + 3 < raw.length; i += 4) {
+    values.push(raw.readUInt32LE(i));
+  }
+  return values;
+}
+
+function popcount32(n: number): number {
+  n = n - ((n >> 1) & 0x55555555);
+  n = (n & 0x33333333) + ((n >> 2) & 0x33333333);
+  return (((n + (n >> 4)) & 0x0f0f0f0f) * 0x01010101) >> 24;
+}
+
+interface FingerprintCandidate {
+  trackId: string;
+  recordId: string;
+  fingerprint: number[];
+}
+
+interface MatchResult {
+  trackId: string;
+  recordId: string;
+  similarity: number;
+}
+
+export function compareFingerprints(
+  query: number[],
+  candidates: FingerprintCandidate[]
+): MatchResult | null {
+  let bestMatch: MatchResult | null = null;
+
+  for (const candidate of candidates) {
+    const len = Math.min(query.length, candidate.fingerprint.length);
+    if (len === 0) continue;
+
+    let errorBits = 0;
+    let totalBits = 0;
+
+    for (let i = 0; i < len; i++) {
+      errorBits += popcount32(query[i] ^ candidate.fingerprint[i]);
+      totalBits += 32;
+    }
+
+    const similarity = 1 - errorBits / totalBits;
+
+    if (similarity > 0.5 && (!bestMatch || similarity > bestMatch.similarity)) {
+      bestMatch = {
+        trackId: candidate.trackId,
+        recordId: candidate.recordId,
+        similarity,
+      };
+    }
+  }
+
+  return bestMatch;
+}

--- a/lib/musicbrainz.ts
+++ b/lib/musicbrainz.ts
@@ -1,0 +1,104 @@
+const BASE_URL = "https://musicbrainz.org/ws/2";
+const COVER_ART_URL = "https://coverartarchive.org";
+const USER_AGENT = "EthanWellsPortfolio/1.0 (https://www.ewells.dev)";
+
+export interface MBRelease {
+  id: string;
+  title: string;
+  artist: string;
+  year: number | null;
+  trackCount: number;
+}
+
+export interface MBTrack {
+  title: string;
+  trackNumber: number;
+  discNumber: number;
+  duration: number | null;
+  recordingMbid: string;
+}
+
+async function mbFetch(path: string): Promise<Response> {
+  return fetch(`${BASE_URL}${path}`, {
+    headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function searchReleases(query: string): Promise<MBRelease[]> {
+  const res = await mbFetch(
+    `/release?query=${encodeURIComponent(query)}&fmt=json&limit=10`
+  );
+  if (!res.ok) return [];
+
+  const data = await res.json();
+  const releases = data.releases ?? [];
+
+  return releases.map(
+    (r: {
+      id: string;
+      title: string;
+      "artist-credit"?: { name: string }[];
+      date?: string;
+      "track-count"?: number;
+    }) => ({
+      id: r.id,
+      title: r.title,
+      artist: r["artist-credit"]?.[0]?.name ?? "Unknown Artist",
+      year: r.date ? parseInt(r.date.slice(0, 4), 10) || null : null,
+      trackCount: r["track-count"] ?? 0,
+    })
+  );
+}
+
+export async function getReleaseTracks(
+  releaseId: string
+): Promise<MBTrack[]> {
+  await sleep(1100);
+  const res = await mbFetch(
+    `/release/${releaseId}?inc=recordings&fmt=json`
+  );
+  if (!res.ok) return [];
+
+  const data = await res.json();
+  const tracks: MBTrack[] = [];
+
+  const media = data.media ?? [];
+  for (const disc of media) {
+    const discNumber = disc.position ?? 1;
+    for (const track of disc.tracks ?? []) {
+      tracks.push({
+        title: track.title,
+        trackNumber: track.position ?? track.number ?? 0,
+        discNumber,
+        duration: track.length ? Math.round(track.length / 1000) : null,
+        recordingMbid: track.recording?.id ?? null,
+      });
+    }
+  }
+
+  return tracks;
+}
+
+export async function getCoverArtUrl(
+  releaseId: string
+): Promise<string | null> {
+  try {
+    await sleep(1100);
+    const res = await fetch(`${COVER_ART_URL}/release/${releaseId}`, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+    });
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    const front = data.images?.find(
+      (img: { front?: boolean }) => img.front
+    );
+    return front?.image ?? data.images?.[0]?.image ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -1,29 +1,13 @@
-import { ListObjectsV2Command, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { ListObjectsV2Command, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { awsCredentialsProvider } from "@vercel/functions/oidc";
 import sharp from "sharp";
 import exifr from "exifr";
 import type { ExifData, Photo } from "@/types";
-
-function buildS3Client() {
-  if (process.env.VERCEL) {
-    return new S3Client({
-      region: process.env.AWS_REGION,
-      credentials: awsCredentialsProvider({ roleArn: process.env.AWS_ROLE_ARN! }),
-    });
-  }
-  return new S3Client({ region: process.env.AWS_REGION });
-}
+import { buildS3Client, bucket, cdnUrl } from "@/lib/aws";
 
 const s3 = buildS3Client();
-const bucket = process.env.S3_BUCKET_NAME!;
 const thumbnailPrefix = process.env.S3_THUMBNAIL_PREFIX!;
 const webPrefix = process.env.S3_WEB_PREFIX!;
-const cdnDomain = process.env.CLOUDFRONT_DOMAIN!;
-
-function cdnUrl(key: string): string {
-  return `https://${cdnDomain}/${key}`;
-}
 
 export async function listFolder(prefix: string): Promise<string[]> {
   const keys: string[] = [];

--- a/lib/vinyl.ts
+++ b/lib/vinyl.ts
@@ -5,6 +5,7 @@ import {
   DeleteCommand,
   QueryCommand,
   BatchWriteCommand,
+  UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { buildDynamoClient } from "@/lib/aws";
 import type {
@@ -122,6 +123,41 @@ export async function deleteRecordAndTracks(id: string): Promise<void> {
   }
 
   await db.send(new DeleteCommand({ TableName: recordsTable, Key: { id } }));
+}
+
+export async function findTrackByMbid(
+  mbid: string
+): Promise<VinylTrack | null> {
+  const result = await db.send(
+    new ScanCommand({
+      TableName: tracksTable,
+      FilterExpression: "mbid = :mbid",
+      ExpressionAttributeValues: { ":mbid": mbid },
+      Limit: 1,
+    })
+  );
+  return (result.Items?.[0] as VinylTrack) ?? null;
+}
+
+export async function updateTrackFingerprint(
+  trackId: string,
+  fingerprint: number[]
+): Promise<void> {
+  await db.send(
+    new UpdateCommand({
+      TableName: tracksTable,
+      Key: { id: trackId },
+      UpdateExpression: "SET fingerprint = :fp",
+      ExpressionAttributeValues: { ":fp": fingerprint },
+    })
+  );
+}
+
+export async function getTrack(trackId: string): Promise<VinylTrack | null> {
+  const result = await db.send(
+    new GetCommand({ TableName: tracksTable, Key: { id: trackId } })
+  );
+  return (result.Item as VinylTrack) ?? null;
 }
 
 export async function getAllFingerprints(): Promise<

--- a/lib/vinyl.ts
+++ b/lib/vinyl.ts
@@ -1,0 +1,145 @@
+import {
+  ScanCommand,
+  GetCommand,
+  PutCommand,
+  DeleteCommand,
+  QueryCommand,
+  BatchWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { buildDynamoClient } from "@/lib/aws";
+import type {
+  VinylRecord,
+  VinylTrack,
+  VinylRecordWithTracks,
+  VinylCollectionStats,
+} from "@/types";
+
+const db = buildDynamoClient();
+const recordsTable = process.env.DYNAMODB_VINYL_RECORDS_TABLE!;
+const tracksTable = process.env.DYNAMODB_VINYL_TRACKS_TABLE!;
+
+export async function getAllRecords(): Promise<VinylRecord[]> {
+  const result = await db.send(new ScanCommand({ TableName: recordsTable }));
+  const records = (result.Items ?? []) as VinylRecord[];
+  return records.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+}
+
+export async function getRecord(id: string): Promise<VinylRecord | null> {
+  const result = await db.send(
+    new GetCommand({ TableName: recordsTable, Key: { id } })
+  );
+  return (result.Item as VinylRecord) ?? null;
+}
+
+export async function getRecordWithTracks(
+  id: string
+): Promise<VinylRecordWithTracks | null> {
+  const record = await getRecord(id);
+  if (!record) return null;
+
+  const result = await db.send(
+    new QueryCommand({
+      TableName: tracksTable,
+      IndexName: "record_id-index",
+      KeyConditionExpression: "recordId = :rid",
+      ExpressionAttributeValues: { ":rid": id },
+    })
+  );
+
+  const tracks = ((result.Items ?? []) as VinylTrack[]).sort(
+    (a, b) => a.discNumber - b.discNumber || a.trackNumber - b.trackNumber
+  );
+
+  return { ...record, tracks };
+}
+
+export async function getCollectionStats(): Promise<VinylCollectionStats> {
+  const records = await getAllRecords();
+  const artists = new Set(records.map((r) => r.artist));
+
+  const totalTracks = records.reduce((sum, r) => sum + r.trackCount, 0);
+
+  return {
+    totalRecords: records.length,
+    totalTracks,
+    uniqueArtists: artists.size,
+  };
+}
+
+export async function createRecord(record: VinylRecord): Promise<void> {
+  await db.send(new PutCommand({ TableName: recordsTable, Item: record }));
+}
+
+export async function createTracks(tracks: VinylTrack[]): Promise<void> {
+  const chunks: VinylTrack[][] = [];
+  for (let i = 0; i < tracks.length; i += 25) {
+    chunks.push(tracks.slice(i, i + 25));
+  }
+
+  for (const chunk of chunks) {
+    await db.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          [tracksTable]: chunk.map((track) => ({
+            PutRequest: { Item: track },
+          })),
+        },
+      })
+    );
+  }
+}
+
+export async function deleteRecordAndTracks(id: string): Promise<void> {
+  const result = await db.send(
+    new QueryCommand({
+      TableName: tracksTable,
+      IndexName: "record_id-index",
+      KeyConditionExpression: "recordId = :rid",
+      ExpressionAttributeValues: { ":rid": id },
+      ProjectionExpression: "id",
+    })
+  );
+
+  const trackIds = (result.Items ?? []).map((item) => item.id as string);
+
+  const chunks: string[][] = [];
+  for (let i = 0; i < trackIds.length; i += 25) {
+    chunks.push(trackIds.slice(i, i + 25));
+  }
+
+  for (const chunk of chunks) {
+    await db.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          [tracksTable]: chunk.map((trackId) => ({
+            DeleteRequest: { Key: { id: trackId } },
+          })),
+        },
+      })
+    );
+  }
+
+  await db.send(new DeleteCommand({ TableName: recordsTable, Key: { id } }));
+}
+
+export async function getAllFingerprints(): Promise<
+  { trackId: string; recordId: string; fingerprint: number[] }[]
+> {
+  const result = await db.send(
+    new ScanCommand({
+      TableName: tracksTable,
+      FilterExpression: "attribute_exists(fingerprint)",
+      ProjectionExpression: "id, recordId, fingerprint",
+    })
+  );
+
+  return (result.Items ?? [])
+    .filter((item) => item.fingerprint && item.fingerprint.length > 0)
+    .map((item) => ({
+      trackId: item.id as string,
+      recordId: item.recordId as string,
+      fingerprint: item.fingerprint as number[],
+    }));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1002.0",
         "@aws-sdk/client-s3": "^3.391.0",
         "@aws-sdk/credential-providers": "^3.1002.0",
+        "@aws-sdk/lib-dynamodb": "^3.1002.0",
         "@aws-sdk/s3-request-presigner": "^3.1001.0",
         "@emotion/cache": "^11.13.0",
         "@emotion/react": "^11.13.0",
@@ -281,6 +283,59 @@
         "@smithy/util-middleware": "^4.2.10",
         "@smithy/util-retry": "^4.2.10",
         "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1002.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1002.0.tgz",
+      "integrity": "sha512-qwIQ7fXHJh/MLkabEEnYgY7NfOL6lbZeI9P29HzSo8jMp3c+uxHkZF/xlyLcArky/YEn5FFhiUF2RUzbsUAUjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/credential-provider-node": "^3.972.16",
+        "@aws-sdk/dynamodb-codec": "^3.972.18",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.6",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.17",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.2",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-retry": "^4.4.38",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.37",
+        "@smithy/util-defaults-mode-node": "^4.2.40",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/util-waiter": "^4.2.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -595,6 +650,56 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.972.18.tgz",
+      "integrity": "sha512-PKD3kBKmj0nvAgzYfV7cdjJ3z0sSxtoYiw5t1WTLedksyRW1RNBvpVDXDI7nt9xpcn6K7Ui1P7VV05yoiQxzDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.17",
+        "@smithy/core": "^3.23.7",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.3.tgz",
+      "integrity": "sha512-s5oiwOTe0ajI5y/cRMsThZsmlrZiAEcUct723O9NivR/es8fDtglbhHo7eQE4ydddCivFCm2lpNj8RPDLdL3AA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1002.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1002.0.tgz",
+      "integrity": "sha512-zxS1q4yrMbvF8yl274CsfO8myNtijefnnU37CukP6H2CrNTE2Qoo1oZ3Ixgisz2jd7Rx1WAsSnXh7EUxEsLEjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/util-dynamodb": "^3.996.1",
+        "@smithy/core": "^3.23.7",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1002.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.972.6",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.6.tgz",
@@ -607,6 +712,23 @@
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
         "@smithy/util-config-provider": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.6.tgz",
+      "integrity": "sha512-p5DYw2cpnsuT/bFA4DEBxucY/wn3TVGDZ7wonEds6EEox35I5DThCsw6aWDIN/fTpG0FMLO3q7s1PUKozWl3CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.3",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -911,6 +1033,21 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.1.tgz",
+      "integrity": "sha512-5Vle00DrIcao9x5UuhkEprIQiMuhVvrxSLQwEhTb1sfWvdrLphcW4LqAtOkWSHpWF9ZdQQVKXvAOjKNV8LSlrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.997.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
@@ -6498,6 +6635,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6747,6 +6893,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1002.0",
     "@aws-sdk/client-s3": "^3.391.0",
     "@aws-sdk/credential-providers": "^3.1002.0",
+    "@aws-sdk/lib-dynamodb": "^3.1002.0",
     "@aws-sdk/s3-request-presigner": "^3.1001.0",
     "@emotion/cache": "^11.13.0",
     "@emotion/react": "^11.13.0",

--- a/types.ts
+++ b/types.ts
@@ -30,3 +30,36 @@ export interface PhotosResponse {
   photos: Photo[];
   album?: string;
 }
+
+export interface VinylRecord {
+  id: string;
+  title: string;
+  artist: string;
+  year: number | null;
+  mbid: string;
+  coverKey: string | null;
+  coverUrl: string | null;
+  trackCount: number;
+  createdAt: string;
+}
+
+export interface VinylTrack {
+  id: string;
+  recordId: string;
+  title: string;
+  trackNumber: number;
+  discNumber: number;
+  duration: number | null;
+  mbid: string | null;
+  fingerprint: number[] | null;
+}
+
+export interface VinylRecordWithTracks extends VinylRecord {
+  tracks: VinylTrack[];
+}
+
+export interface VinylCollectionStats {
+  totalRecords: number;
+  totalTracks: number;
+  uniqueArtists: number;
+}


### PR DESCRIPTION
## Summary
- Shared AWS client factory (S3 + DynamoDB OIDC) extracted from lib/s3.ts
- DynamoDB-backed vinyl record and track storage with full CRUD
- MusicBrainz search/import, Cover Art Archive album art upload to S3, AcoustID fingerprint lookup
- Admin import wizard at /admin/vinyl (session-gated, mobile-friendly)
- Public collection grid at /vinyl with album detail pages
- Fingerprint identification API at /api/vinyl/identify (API key auth) for Raspberry Pi spectrum analyzer
- Vinyl nav link in desktop and mobile nav

## Env vars required
- `DYNAMODB_VINYL_RECORDS_TABLE` / `DYNAMODB_VINYL_TRACKS_TABLE`
- `ACOUSTID_API_KEY`
- `VINYL_IDENTIFY_API_KEY`